### PR TITLE
fixed duplicated container names

### DIFF
--- a/morevolumes.yaml
+++ b/morevolumes.yaml
@@ -4,7 +4,7 @@ metadata:
   name: morevol2
 spec:
   containers:
-  - name: centos
+  - name: centos01
     image: centos:7
     command:
       - sleep
@@ -12,7 +12,7 @@ spec:
     volumeMounts:
       - mountPath: /centos
         name: test
-  - name: centos
+  - name: centos02
     image: centos:7
     command:
       - sleep


### PR DESCRIPTION
fixes following error.

```
oc create -f ex280/morevolumes.yaml
The Pod "morevol2" is invalid: spec.containers[1].name: Duplicate value: "centos"
```